### PR TITLE
implement automated build pipeline for WebAssemblyci: add GitHub Actions workflow for Rust WASM build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: Rust WASM CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+      - name: Build WebAssembly
+        run: cargo build --target wasm32-unknown-unknown --release


### PR DESCRIPTION
Description
This PR introduces a GitHub Actions workflow to automate the Continuous Integration (CI) process.

Changes Made:
- Added `.github/workflows/ci.yml`
- Configured Rust toolchain with `wasm32-unknown-unknown` target.
- Added automated format checking (`cargo fmt`).
- Added automated release build testing for WebAssembly.